### PR TITLE
Allow asymetric encryption to specified recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ Parameters available in the root object:
 | notifications | A list of mechanisms by which to report success/failure. |
 
 
+Common Source parameters
+------------------------
+
+| Config key | Purpose |
+|------------|---------|
+| passphrase | A passphrase to encrypt the backup with (using GnuPG). |
+| recipients | (Optional) If recipients are provided, the encrypted backup is encrypted for the list of recipients specified. If recipients are not provided, the backup symetrically encrypted using the given passphrase |
+
+
 Source - Folder
 ---------------
 
@@ -155,7 +164,6 @@ Parameters available in 'folder':
 |------------|----------|
 | name |  Description of data being backed up (for reporting purposes). |
 | path | Name of file or folder to be backed up. |
-| passphrase | A passphrase to encrypt the backup with (using GnuPG). |
 | excludes | One or more files/paths to be excluded from the backup. |
 
 

--- a/backups/encrypt.py
+++ b/backups/encrypt.py
@@ -12,7 +12,7 @@ def encrypt(filename, passphrase=None, recipients=None):
     encerrs = open(encerrsname, 'wb')
     encargs = ['gpg', '--batch', '--yes', '-q']
     if recipients is not None:
-        encargs += ['--trust-model', 'all', '--encrypt']
+        encargs += ['--trust-model', 'always', '--encrypt']
         for r in recipients:
             encargs += ['-r', r]
     elif passphrase is not None:
@@ -21,9 +21,8 @@ def encrypt(filename, passphrase=None, recipients=None):
         raise BackupException("Misconfigured encryption")
     encenv = os.environ.copy()
     encproc1 = subprocess.Popen(encargs, stdin=subprocess.PIPE, stdout=encfile, stderr=encerrs, env=encenv)
-    encproc1.communicate(passphrase.encode('utf8'))
-    #if encproc1.stdout:
-    #    encproc1.stdout.close()
+    if passphrase is not None:
+        encproc1.communicate(passphrase.encode('utf8'))
     encproc1.wait()
     encfile.close()
     encerrs.close()

--- a/backups/sources/source.py
+++ b/backups/sources/source.py
@@ -12,8 +12,12 @@ class BackupSource:
         self.type = type
         self.suffix = suffix
         self.tmpdir = "/var/tmp"
+        self.recipients = []
+        self.passphrase = ""
         if 'name' in config:
             self.name = config['name']
+        if 'recipients' in config:
+            self.recipients = config['recipients']
         if 'passphrase' in config:
             self.passphrase = config['passphrase']
         if 'tmpdir' in config:
@@ -35,8 +39,11 @@ class BackupSource:
         for filename in filenames:
             if self.compress:
                 compressed_filename = backups.compress.compress(filename)
+            elif len(self.recipients) > 0:
+                compressed_filename = backups.encrypt.encrypt(filename, recipients=self.recipients)
+                os.unlink(filename)
             else:
-                compressed_filename = backups.encrypt.encrypt(filename, self.passphrase)
+                compressed_filename = backups.encrypt.encrypt(filename, passphrase=self.passphrase)
                 os.unlink(filename)
             compressed_files.append(compressed_filename)
         e_endtime = time.time()


### PR DESCRIPTION
Add ability to encrypt backups so only specified recipients can decrypt (asymmetric) as opposed to decryption with the passphrase used to encrypt it (symmetric).