### PR TITLE
Fix Flagfile notification missing notify_on_start attribute

### DIFF
--- a/backups/notifications/flagfile.py
+++ b/backups/notifications/flagfile.py
@@ -7,6 +7,7 @@ from backups.notifications.notification import BackupNotification
 @backupnotification('flagfile')
 class Flagfile(BackupNotification):
     def __init__(self, config):
+        BackupNotification.__init__(self, config, 'flagfile')
         self.filename = config['flagfile']
         self.notify_on_success = True
         self.notify_on_failure = False


### PR DESCRIPTION
The Flagfile class was not calling the parent BackupNotification.__init__, which initializes notify_on_start and other notification flags. This caused an AttributeError when _notify_start tried to access self.notify_on_start.

Added the missing BackupNotification.__init__(self, config, 'flagfile') call to properly initialize the base class attributes.