### PR TITLE
Add OTLP tracing instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ backups.egg-info
 MANIFEST
 build
 dist
+*.tar.gz
+*.deb
+deb_dist/
+stdeb.cfg

--- a/README.md
+++ b/README.md
@@ -52,10 +52,17 @@ Or asymmetric (GPG public key):
 
 OpenTelemetry OTLP tracing is supported for observability. Tracing is disabled by default (zero performance impact).
 
+Install the optional tracing dependencies:
+
+```bash
+pip install backups[tracing]
+```
+
 To enable tracing:
-- Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to your OTLP collector/backend URL (e.g., `http://localhost:4317` for gRPC).
+- Set `OTEL_EXPORTER_OTLP_ENDPOINT` to your OTLP collector URL (e.g., `http://localhost:4317` for gRPC).
 - Optional: Set `OTEL_EXPORTER_OTLP_HEADERS` for authentication (e.g., `authorization=Bearer token`).
-- Optional: Set `OTEL_TRACES_SAMPLER` to control sampling (default: `traceidratio:0.1` for 10% sampling).
+- Optional: Set `OTEL_EXPORTER_OTLP_INSECURE=true` to disable TLS (default: TLS enabled).
+- Optional: Set `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` to control sampling (e.g., `OTEL_TRACES_SAMPLER=traceidratio` and `OTEL_TRACES_SAMPLER_ARG=0.1` for 10%).
 
 Example:
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Or asymmetric (GPG public key):
 }
 ```
 
+## Tracing Configuration
+
+OpenTelemetry OTLP tracing is supported for observability. Tracing is disabled by default (zero performance impact).
+
+To enable tracing:
+- Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to your OTLP collector/backend URL (e.g., `http://localhost:4317` for gRPC).
+- Optional: Set `OTEL_EXPORTER_OTLP_HEADERS` for authentication (e.g., `authorization=Bearer token`).
+- Optional: Set `OTEL_TRACES_SAMPLER` to control sampling (default: `traceidratio:0.1` for 10% sampling).
+
+Example:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+backups /etc/backups/production.json
+```
+
+Traces include spans for backup runs, source processing, dump/compress, uploads, cleanup, and notifications, with attributes for timing, file counts, and errors.
+
 ## Sources
 
 | Type | Description | Docs |

--- a/backups/main.py
+++ b/backups/main.py
@@ -11,12 +11,27 @@ import logging
 import logging.handlers
 import json
 
+# OpenTelemetry imports (optional)
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBasedSampler
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
 import backups.stats
 import backups.sources
 import backups.destinations
 import backups.notifications
 
 from backups.exceptions import BackupException
+
+# Global tracer (initialized if OTEL enabled)
+tracer = None
 
 # Default set of modules to import
 default_modules = [
@@ -52,6 +67,91 @@ class BackupRunInstance:
         self.stats = backups.stats.BackupRunStatistics()
 
     def run(self):
+        if tracer:
+            with tracer.start_as_current_span("backup_run") as root_span:
+                root_span.set_attribute("hostname", self.hostname)
+                self._run_with_tracing()
+        else:
+            self._run_without_tracing()
+
+    def _run_with_tracing(self):
+        # Loop through the defined source modules...
+        for source in self.sources:
+            with tracer.start_as_current_span("process_source") as source_span:
+                source_span.set_attribute("source.id", source.id)
+                source_span.set_attribute("source.name", source.name)
+                source_span.set_attribute("hostname", self.hostname)
+
+                # Trigger notifications as required
+                for notification in self.notifications:
+                    with tracer.start_as_current_span("notify_start") as notify_span:
+                        notify_span.set_attribute("notification.type", notification.__class__.__name__)
+                        notification._notify_start(source, self.hostname)
+
+                try:
+                    # Dump and compress
+                    starttime = time.time()
+                    self.stats.starttime = datetime.datetime.now()
+                    with tracer.start_as_current_span("dump_and_compress") as dump_span:
+                        dumpfiles = source.dump_and_compress(self.stats)
+                        if not isinstance(dumpfiles, list):
+                            dumpfiles = [dumpfiles, ]
+                    endtime = time.time()
+                    self.stats.dumptime = endtime - starttime
+                    dump_span.set_attribute("dumptime", self.stats.dumptime)
+                    dump_span.set_attribute("file.count", len(dumpfiles))
+
+                    # Add up backup file sizes
+                    totalsize = 0
+                    for dumpfile in dumpfiles:
+                        totalsize = totalsize + os.path.getsize(dumpfile)
+                    self.stats.size = totalsize
+                    dump_span.set_attribute("total.size", totalsize)
+
+                    # Send each dump file to each listed destination
+                    starttime = time.time()
+                    self.stats.dumpedfiles = []
+                    self.stats.retainedfiles = []
+                    with tracer.start_as_current_span("upload_files") as upload_span:
+                        for dumpfile in dumpfiles:
+                            for destination in self.destinations:
+                                uploaded = destination.send(source.id, source.name, dumpfile)
+                                self.stats.dumpedfiles.append(uploaded)
+                                retained = destination.cleanup(source.id, source.name)
+                                self.stats.retainedfiles += retained
+                    endtime = time.time()
+                    self.stats.endtime = datetime.datetime.now()
+                    self.stats.uploadtime = endtime - starttime
+                    upload_span.set_attribute("uploadtime", self.stats.uploadtime)
+                    upload_span.set_attribute("dumped.count", len(self.stats.dumpedfiles))
+                    upload_span.set_attribute("retained.count", len(self.stats.retainedfiles))
+
+                    # Trigger success notifications as required
+                    for notification in self.notifications:
+                        with tracer.start_as_current_span("notify_success") as notify_span:
+                            notify_span.set_attribute("notification.type", notification.__class__.__name__)
+                            notification._notify_success(source, self.hostname, dumpfile, self.stats)
+
+                except Exception as e:
+                    import traceback
+                    traceback.print_exc()
+                    trace.get_current_span().record_exception(e)
+                    trace.get_current_span().set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
+                    # Trigger notifications as required
+                    for notification in self.notifications:
+                        with tracer.start_as_current_span("notify_failure") as notify_span:
+                            notify_span.set_attribute("notification.type", notification.__class__.__name__)
+                            notify_span.set_attribute("error", str(e))
+                            notification._notify_failure(source, self.hostname, e)
+
+                finally:
+                    # Done with the dump file now
+                    if 'dumpfile' in locals() and os.path.isfile(dumpfile):
+                       os.unlink(dumpfile)
+
+        logging.debug("Complete.")
+
+    def _run_without_tracing(self):
         # Loop through the defined source modules...
         for source in self.sources:
             # Trigger notifications as required
@@ -118,6 +218,27 @@ def main():
         args = parser.parse_args()
         configfile = args.configfile[0]
 
+        # Initialize OpenTelemetry tracing if OTEL_EXPORTER_OTLP_ENDPOINT is set
+        global tracer
+        if OTEL_AVAILABLE and os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+            resource = Resource.create({
+                SERVICE_NAME: "backups",
+                "service.version": "2.5.0",
+            })
+            trace_provider = TracerProvider(
+                resource=resource,
+                sampler=TraceIdRatioBasedSampler(0.1)  # Sample 10% of traces
+            )
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+                insecure=True,  # Assume insecure for now; can be made configurable
+            )
+            span_processor = BatchSpanProcessor(otlp_exporter)
+            trace_provider.add_span_processor(span_processor)
+            trace.set_tracer_provider(trace_provider)
+            tracer = trace.get_tracer("backups.tracer")
+            logging.info("OpenTelemetry tracing enabled.")
+
         # Enable logging if verbosity requested
         if args.debug:
             logging.basicConfig(level=logging.DEBUG)
@@ -174,6 +295,11 @@ def main():
         instance.sources = sources
         instance.destinations = destinations
         instance.run()
+
+        # Shutdown tracing if enabled
+        if tracer:
+            trace.get_tracer_provider().shutdown()
+            logging.info("OpenTelemetry tracing shut down.")
 
     except KeyboardInterrupt :
         sys.exit()

--- a/backups/main.py
+++ b/backups/main.py
@@ -3,24 +3,26 @@
 import os
 import os.path
 import sys
+import contextlib
 import datetime
 import time
+import traceback
 import argparse
 import getpass
 import logging
 import logging.handlers
 import json
 
-# OpenTelemetry imports (optional)
+# OpenTelemetry imports (optional SDK/exporter; shim used when unavailable)
 try:
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-    from opentelemetry.sdk.trace.sampling import TraceIdRatioBasedSampler
     OTEL_AVAILABLE = True
 except ImportError:
+    trace = None
     OTEL_AVAILABLE = False
 
 import backups.stats
@@ -30,8 +32,24 @@ import backups.notifications
 
 from backups.exceptions import BackupException
 
-# Global tracer (initialized if OTEL enabled)
-tracer = None
+try:
+    from importlib.metadata import version as _pkg_version
+    _SERVICE_VERSION = _pkg_version("backups")
+except Exception:
+    _SERVICE_VERSION = "unknown"
+
+
+class _NoOpSpan:
+    def set_attribute(self, *args, **kwargs): pass
+    def record_exception(self, *args, **kwargs): pass
+    def set_status(self, *args, **kwargs): pass
+
+
+class _NoOpTracer:
+    @contextlib.contextmanager
+    def start_as_current_span(self, name, **kwargs):
+        yield _NoOpSpan()
+
 
 # Default set of modules to import
 default_modules = [
@@ -65,151 +83,86 @@ class BackupRunInstance:
         self.notifications = []
 
         self.stats = backups.stats.BackupRunStatistics()
+        self.tracer = _NoOpTracer()
 
     def run(self):
-        if tracer:
-            with tracer.start_as_current_span("backup_run") as root_span:
-                root_span.set_attribute("hostname", self.hostname)
-                self._run_with_tracing()
-        else:
-            self._run_without_tracing()
+        with self.tracer.start_as_current_span("backup_run") as root_span:
+            root_span.set_attribute("hostname", self.hostname)
 
-    def _run_with_tracing(self):
-        # Loop through the defined source modules...
-        for source in self.sources:
-            with tracer.start_as_current_span("process_source") as source_span:
-                source_span.set_attribute("source.id", source.id)
-                source_span.set_attribute("source.name", source.name)
-                source_span.set_attribute("hostname", self.hostname)
+            for source in self.sources:
+                with self.tracer.start_as_current_span("process_source") as source_span:
+                    source_span.set_attribute("source.id", source.id)
+                    source_span.set_attribute("source.name", source.name)
+                    source_span.set_attribute("hostname", self.hostname)
 
-                # Trigger notifications as required
-                for notification in self.notifications:
-                    with tracer.start_as_current_span("notify_start") as notify_span:
-                        notify_span.set_attribute("notification.type", notification.__class__.__name__)
-                        notification._notify_start(source, self.hostname)
-
-                try:
-                    # Dump and compress
-                    starttime = time.time()
-                    self.stats.starttime = datetime.datetime.now()
-                    with tracer.start_as_current_span("dump_and_compress") as dump_span:
-                        dumpfiles = source.dump_and_compress(self.stats)
-                        if not isinstance(dumpfiles, list):
-                            dumpfiles = [dumpfiles, ]
-                    endtime = time.time()
-                    self.stats.dumptime = endtime - starttime
-                    dump_span.set_attribute("dumptime", self.stats.dumptime)
-                    dump_span.set_attribute("file.count", len(dumpfiles))
-
-                    # Add up backup file sizes
-                    totalsize = 0
-                    for dumpfile in dumpfiles:
-                        totalsize = totalsize + os.path.getsize(dumpfile)
-                    self.stats.size = totalsize
-                    dump_span.set_attribute("total.size", totalsize)
-
-                    # Send each dump file to each listed destination
-                    starttime = time.time()
-                    self.stats.dumpedfiles = []
-                    self.stats.retainedfiles = []
-                    with tracer.start_as_current_span("upload_files") as upload_span:
-                        for dumpfile in dumpfiles:
-                            for destination in self.destinations:
-                                uploaded = destination.send(source.id, source.name, dumpfile)
-                                self.stats.dumpedfiles.append(uploaded)
-                                retained = destination.cleanup(source.id, source.name)
-                                self.stats.retainedfiles += retained
-                    endtime = time.time()
-                    self.stats.endtime = datetime.datetime.now()
-                    self.stats.uploadtime = endtime - starttime
-                    upload_span.set_attribute("uploadtime", self.stats.uploadtime)
-                    upload_span.set_attribute("dumped.count", len(self.stats.dumpedfiles))
-                    upload_span.set_attribute("retained.count", len(self.stats.retainedfiles))
-
-                    # Trigger success notifications as required
                     for notification in self.notifications:
-                        with tracer.start_as_current_span("notify_success") as notify_span:
+                        with self.tracer.start_as_current_span("notify_start") as notify_span:
                             notify_span.set_attribute("notification.type", notification.__class__.__name__)
-                            notification._notify_success(source, self.hostname, dumpfile, self.stats)
+                            try:
+                                notification._notify_start(source, self.hostname)
+                            except Exception as e:
+                                logging.error("Error sending start notification (%s): %s", type(notification), e)
 
-                except Exception as e:
-                    import traceback
-                    traceback.print_exc()
-                    trace.get_current_span().record_exception(e)
-                    trace.get_current_span().set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
-                    # Trigger notifications as required
-                    for notification in self.notifications:
-                        with tracer.start_as_current_span("notify_failure") as notify_span:
-                            notify_span.set_attribute("notification.type", notification.__class__.__name__)
-                            notify_span.set_attribute("error", str(e))
-                            notification._notify_failure(source, self.hostname, e)
-
-                finally:
-                    # Done with the dump file now
-                    if 'dumpfile' in locals() and os.path.isfile(dumpfile):
-                       os.unlink(dumpfile)
-
-        logging.debug("Complete.")
-
-    def _run_without_tracing(self):
-        # Loop through the defined source modules...
-        for source in self.sources:
-            # Trigger notifications as required
-            for notification in self.notifications:
-                notification._notify_start(source, self.hostname)
-
-            try:
-                # Dump and compress
-                starttime = time.time()
-                self.stats.starttime = datetime.datetime.now()
-                dumpfiles = source.dump_and_compress(self.stats)
-                if not isinstance(dumpfiles, list):
-                    dumpfiles = [dumpfiles, ]
-                endtime = time.time()
-                self.stats.dumptime = endtime - starttime
-
-                # Add up backup file sizes
-                totalsize = 0
-                for dumpfile in dumpfiles:
-                    totalsize = totalsize + os.path.getsize(dumpfile)
-                self.stats.size = totalsize
-
-                # Send each dump file to each listed destination
-                starttime = time.time()
-                self.stats.dumpedfiles = []
-                self.stats.retainedfiles = []
-                for dumpfile in dumpfiles:
-                    for destination in self.destinations:
-                        self.stats.dumpedfiles.append(destination.send(source.id, source.name, dumpfile))
-                        self.stats.retainedfiles += destination.cleanup(source.id, source.name)
-                endtime = time.time()
-                self.stats.endtime = datetime.datetime.now()
-                self.stats.uploadtime = endtime - starttime
-
-                # Trigger success notifications as required
-                for notification in self.notifications:
                     try:
-                        notification._notify_success(source, self.hostname, dumpfile, self.stats)
+                        starttime = time.time()
+                        self.stats.starttime = datetime.datetime.now()
+                        with self.tracer.start_as_current_span("dump_and_compress") as dump_span:
+                            dumpfiles = source.dump_and_compress(self.stats)
+                            if not isinstance(dumpfiles, list):
+                                dumpfiles = [dumpfiles]
+                            endtime = time.time()
+                            self.stats.dumptime = endtime - starttime
+                            totalsize = sum(os.path.getsize(f) for f in dumpfiles)
+                            self.stats.size = totalsize
+                            dump_span.set_attribute("dumptime", self.stats.dumptime)
+                            dump_span.set_attribute("file.count", len(dumpfiles))
+                            dump_span.set_attribute("total.size", totalsize)
+
+                        starttime = time.time()
+                        self.stats.dumpedfiles = []
+                        self.stats.retainedfiles = []
+                        with self.tracer.start_as_current_span("upload_files") as upload_span:
+                            for dumpfile in dumpfiles:
+                                for destination in self.destinations:
+                                    uploaded = destination.send(source.id, source.name, dumpfile)
+                                    self.stats.dumpedfiles.append(uploaded)
+                                    retained = destination.cleanup(source.id, source.name)
+                                    self.stats.retainedfiles += retained
+                            endtime = time.time()
+                            self.stats.endtime = datetime.datetime.now()
+                            self.stats.uploadtime = endtime - starttime
+                            upload_span.set_attribute("uploadtime", self.stats.uploadtime)
+                            upload_span.set_attribute("dumped.count", len(self.stats.dumpedfiles))
+                            upload_span.set_attribute("retained.count", len(self.stats.retainedfiles))
+
+                        for notification in self.notifications:
+                            with self.tracer.start_as_current_span("notify_success") as notify_span:
+                                notify_span.set_attribute("notification.type", notification.__class__.__name__)
+                                try:
+                                    notification._notify_success(source, self.hostname, dumpfile, self.stats)
+                                except Exception as e:
+                                    logging.error("Error sending success notification (%s): %s", type(notification), e)
+
                     except Exception as e:
-                        logging.error("Error sending success notification (%s): %s" % (type(notification), e.__str__()))
+                        traceback.print_exc()
+                        source_span.record_exception(e)
+                        if OTEL_AVAILABLE:
+                            source_span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
+                        for notification in self.notifications:
+                            with self.tracer.start_as_current_span("notify_failure") as notify_span:
+                                notify_span.set_attribute("notification.type", notification.__class__.__name__)
+                                notify_span.set_attribute("error", str(e))
+                                try:
+                                    notification._notify_failure(source, self.hostname, e)
+                                except Exception as e2:
+                                    logging.error("Error sending failure notification (%s): %s", type(notification), e2)
+                                    logging.error("Original error was: %s", e)
 
-            except Exception as e:
-                import traceback
-                traceback.print_exc()
-                # Trigger notifications as required
-                for notification in self.notifications:
-                    try:
-                        notification._notify_failure(source, self.hostname, e)
-                    except Exception as e2:
-                        logging.error("Error sending failure notification (%s): %s" % (type(notification), e2.__str__()))
-                        logging.error("Original error was: %s" % e.__str__())
+                    finally:
+                        if 'dumpfile' in locals() and os.path.isfile(dumpfile):
+                            os.unlink(dumpfile)
 
-            finally:
-                # Done with the dump file now
-                if 'dumpfile' in locals() and os.path.isfile(dumpfile):
-                   os.unlink(dumpfile)
-
-        logging.debug("Complete.")
+            logging.debug("Complete.")
 
 def main():
     try:
@@ -226,24 +179,23 @@ def main():
         configfile = args.configfile[0]
 
         # Initialize OpenTelemetry tracing if OTEL_EXPORTER_OTLP_ENDPOINT is set
-        global tracer
+        otel_tracer = _NoOpTracer()
+        trace_provider = None
         if OTEL_AVAILABLE and os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
             resource = Resource.create({
                 SERVICE_NAME: "backups",
-                "service.version": "2.5.0",
+                "service.version": _SERVICE_VERSION,
             })
-            trace_provider = TracerProvider(
-                resource=resource,
-                sampler=TraceIdRatioBasedSampler(0.1)  # Sample 10% of traces
-            )
+            # TracerProvider respects OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG env vars
+            trace_provider = TracerProvider(resource=resource)
+            insecure = os.getenv("OTEL_EXPORTER_OTLP_INSECURE", "false").lower() == "true"
             otlp_exporter = OTLPSpanExporter(
                 endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
-                insecure=True,  # Assume insecure for now; can be made configurable
+                insecure=insecure,
             )
-            span_processor = BatchSpanProcessor(otlp_exporter)
-            trace_provider.add_span_processor(span_processor)
+            trace_provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
             trace.set_tracer_provider(trace_provider)
-            tracer = trace.get_tracer("backups.tracer")
+            otel_tracer = trace.get_tracer("backups.tracer")
             logging.info("OpenTelemetry tracing enabled.")
 
         # Enable logging if verbosity requested
@@ -301,11 +253,12 @@ def main():
         instance.notifications = notifications
         instance.sources = sources
         instance.destinations = destinations
+        instance.tracer = otel_tracer
         instance.run()
 
         # Shutdown tracing if enabled
-        if tracer:
-            trace.get_tracer_provider().shutdown()
+        if trace_provider is not None:
+            trace_provider.shutdown()
             logging.info("OpenTelemetry tracing shut down.")
 
     except KeyboardInterrupt :

--- a/backups/main.py
+++ b/backups/main.py
@@ -191,7 +191,7 @@ class BackupRunInstance:
                     try:
                         notification._notify_success(source, self.hostname, dumpfile, self.stats)
                     except Exception as e:
-                        logging.error("Error sending success notification (%s): %s" % (typeof(notification), e.__str__()))
+                        logging.error("Error sending success notification (%s): %s" % (type(notification), e.__str__()))
 
             except Exception as e:
                 import traceback
@@ -201,7 +201,7 @@ class BackupRunInstance:
                     try:
                         notification._notify_failure(source, self.hostname, e)
                     except Exception as e2:
-                        logging.error("Error sending failure notification (%s): %s" % (typeof(notification), e2.__str__()))
+                        logging.error("Error sending failure notification (%s): %s" % (type(notification), e2.__str__()))
                         logging.error("Original error was: %s" % e.__str__())
 
             finally:

--- a/backups/main.py
+++ b/backups/main.py
@@ -188,14 +188,21 @@ class BackupRunInstance:
 
                 # Trigger success notifications as required
                 for notification in self.notifications:
-                    notification._notify_success(source, self.hostname, dumpfile, self.stats)
+                    try:
+                        notification._notify_success(source, self.hostname, dumpfile, self.stats)
+                    except Exception as e:
+                        logging.error("Error sending success notification (%s): %s" % (typeof(notification), e.__str__()))
 
             except Exception as e:
                 import traceback
                 traceback.print_exc()
                 # Trigger notifications as required
                 for notification in self.notifications:
-                    notification._notify_failure(source, self.hostname, e)
+                    try:
+                        notification._notify_failure(source, self.hostname, e)
+                    except Exception as e2:
+                        logging.error("Error sending failure notification (%s): %s" % (typeof(notification), e2.__str__()))
+                        logging.error("Original error was: %s" % e.__str__())
 
             finally:
                 # Done with the dump file now

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,6 @@ minio
 dropbox
 google-api-python-client
 google-auth
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'backups',
-    version = '2.5.0',
+    version = '2.5.1',
     description = 'Data Backup Scripts',
     author = 'Ross Golder',
     author_email = 'ross@golder.org',

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,14 @@ setup(name = 'backups',
     install_requires = [
         'requests',
         'python-dateutil',
-        'opentelemetry-api',
-        'opentelemetry-sdk',
-        'opentelemetry-exporter-otlp-proto-grpc'
     ],
+    extras_require = {
+        'tracing': [
+            'opentelemetry-api',
+            'opentelemetry-sdk',
+            'opentelemetry-exporter-otlp-proto-grpc',
+        ]
+    },
     entry_points = {
         'console_scripts': [
             'backup = backups.main:main'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ setup(name = 'backups',
     ],
     install_requires = [
         'requests',
-        'python-dateutil'
+        'python-dateutil',
+        'opentelemetry-api',
+        'opentelemetry-sdk',
+        'opentelemetry-exporter-otlp-proto-grpc'
     ],
     entry_points = {
         'console_scripts': [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,30 +101,132 @@ class TestBackupRunStatistics:
         stats.size = size
         assert stats.getSizeDescription() == expected
 
+otel = pytest.importorskip("opentelemetry", reason="opentelemetry-sdk not installed")
+
+from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from backups.main import BackupRunInstance
+
+
+def _make_test_tracer():
+    exporter = InMemorySpanExporter()
+    provider = _TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("test"), exporter
+
+
 class TestTracing:
-    @patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"})
-    @patch('backups.main.trace')
-    @patch('backups.main.OTEL_AVAILABLE', True)
-    def test_tracing_enabled(self, mock_trace):
-        mock_tracer_provider = MagicMock()
-        mock_trace.get_tracer_provider.return_value = mock_tracer_provider
-        mock_tracer_provider.shutdown = MagicMock()
+    def _make_instance(self, tracer):
+        instance = BackupRunInstance()
+        instance.tracer = tracer
+        instance.sources = []
+        instance.destinations = []
+        instance.notifications = []
+        return instance
 
-        # Reset global tracer
-        backups.main.tracer = None
+    def test_backup_run_span_created(self):
+        tracer, exporter = _make_test_tracer()
+        instance = self._make_instance(tracer)
+        instance.run()
+        names = [s.name for s in exporter.get_finished_spans()]
+        assert "backup_run" in names
 
-        # Call main init logic (simulate)
-        # Since main() is complex, test the init part
-        # For simplicity, assume init works if no exception
+    def test_source_spans_created(self):
+        tracer, exporter = _make_test_tracer()
+        instance = self._make_instance(tracer)
 
-        # Actually, since it's global, hard to test.
-        # Just check that tracer is set when env is set
-        assert os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None
-        # In real test, would call the init code, but for now, placeholder
+        mock_source = Mock()
+        mock_source.id = "src-1"
+        mock_source.name = "Test Source"
+        mock_source.dump_and_compress.return_value = []
+        instance.sources = [mock_source]
 
-    @patch.dict(os.environ, {}, clear=True)
-    def test_tracing_disabled_by_default(self):
-        # Reset
-        backups.main.tracer = None
-        # Without env, tracer should remain None
-        assert backups.main.tracer is None
+        instance.run()
+        names = [s.name for s in exporter.get_finished_spans()]
+        assert "process_source" in names
+        assert "dump_and_compress" in names
+        assert "upload_files" in names
+
+    def test_span_attributes_set_inside_span(self):
+        tracer, exporter = _make_test_tracer()
+        instance = self._make_instance(tracer)
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"data")
+            tmpfile = f.name
+
+        try:
+            mock_source = Mock()
+            mock_source.id = "src-1"
+            mock_source.name = "Test Source"
+            mock_source.dump_and_compress.return_value = [tmpfile]
+
+            mock_dest = Mock()
+            mock_dest.send.return_value = tmpfile
+            mock_dest.cleanup.return_value = []
+            instance.sources = [mock_source]
+            instance.destinations = [mock_dest]
+
+            instance.run()
+
+            spans = {s.name: s for s in exporter.get_finished_spans()}
+            dump_span = spans["dump_and_compress"]
+            assert dump_span.attributes["file.count"] == 1
+            assert dump_span.attributes["total.size"] == 4
+            assert "dumptime" in dump_span.attributes
+
+            upload_span = spans["upload_files"]
+            assert upload_span.attributes["dumped.count"] == 1
+            assert "uploadtime" in upload_span.attributes
+        finally:
+            if os.path.exists(tmpfile):
+                os.unlink(tmpfile)
+
+    def test_failure_notification_on_source_error(self):
+        tracer, exporter = _make_test_tracer()
+        instance = self._make_instance(tracer)
+
+        mock_source = Mock()
+        mock_source.id = "src-1"
+        mock_source.name = "Test Source"
+        mock_source.dump_and_compress.side_effect = RuntimeError("disk full")
+        instance.sources = [mock_source]
+
+        mock_notification = Mock()
+        instance.notifications = [mock_notification]
+
+        instance.run()
+
+        mock_notification._notify_failure.assert_called_once()
+        names = [s.name for s in exporter.get_finished_spans()]
+        assert "notify_failure" in names
+
+    def test_notification_error_does_not_crash_run(self):
+        tracer, exporter = _make_test_tracer()
+        instance = self._make_instance(tracer)
+
+        mock_source = Mock()
+        mock_source.id = "src-1"
+        mock_source.name = "Test Source"
+        mock_source.dump_and_compress.return_value = []
+        instance.sources = [mock_source]
+
+        mock_notification = Mock()
+        mock_notification._notify_success.side_effect = RuntimeError("notify down")
+        instance.notifications = [mock_notification]
+
+        instance.run()
+
+    def test_noop_tracer_when_otel_disabled(self):
+        instance = BackupRunInstance()
+        assert isinstance(instance.tracer, backups.main._NoOpTracer)
+        mock_source = Mock()
+        mock_source.id = "src-1"
+        mock_source.name = "Test"
+        mock_source.dump_and_compress.return_value = []
+        instance.sources = [mock_source]
+        instance.destinations = []
+        instance.notifications = []
+        instance.run()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,12 @@
 import pytest
 import tempfile
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 from backups.compress import compress
 from backups.encrypt import encrypt
 from backups.stats import BackupRunStatistics
 from backups.exceptions import BackupException
+import backups.main
 
 class TestCompress:
     @patch('subprocess.Popen')
@@ -99,3 +100,31 @@ class TestBackupRunStatistics:
         stats = BackupRunStatistics()
         stats.size = size
         assert stats.getSizeDescription() == expected
+
+class TestTracing:
+    @patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"})
+    @patch('backups.main.trace')
+    @patch('backups.main.OTEL_AVAILABLE', True)
+    def test_tracing_enabled(self, mock_trace):
+        mock_tracer_provider = MagicMock()
+        mock_trace.get_tracer_provider.return_value = mock_tracer_provider
+        mock_tracer_provider.shutdown = MagicMock()
+
+        # Reset global tracer
+        backups.main.tracer = None
+
+        # Call main init logic (simulate)
+        # Since main() is complex, test the init part
+        # For simplicity, assume init works if no exception
+
+        # Actually, since it's global, hard to test.
+        # Just check that tracer is set when env is set
+        assert os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None
+        # In real test, would call the init code, but for now, placeholder
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_tracing_disabled_by_default(self):
+        # Reset
+        backups.main.tracer = None
+        # Without env, tracer should remain None
+        assert backups.main.tracer is None


### PR DESCRIPTION
## Summary
This PR adds OpenTelemetry (OTLP) tracing instrumentation to the backups system, along with error handling for notification failures.

### Changes
- Added OTLP tracing setup in the main backup run instance
- Wrapped notification calls in try-except blocks to prevent notification errors from crashing the backup process
- Log notification errors instead of failing the entire backup

### Commits
- Add OTLP tracing instrumentation
- Add error handling for notification failures