### PR TITLE
Add SFTP folder source

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Traces include spans for backup runs, source processing, dump/compress, uploads,
 |------|-------------|------|
 | `folder` | Local directory via `tar` | [docs/sources/folder.md](docs/sources/folder.md) |
 | `folder-ssh` | Remote directory via SSH + `tar` | [docs/sources/folderssh.md](docs/sources/folderssh.md) |
+| `sftp-folder` | Remote directory via SFTP | [docs/sources/sftpfolder.md](docs/sources/sftpfolder.md) |
 | `mysql` | MySQL/MariaDB via `mysqldump` | [docs/sources/mysql.md](docs/sources/mysql.md) |
 | `mysql-ssh` | MySQL via SSH tunnel | [docs/sources/mysqlssh.md](docs/sources/mysqlssh.md) |
 | `postgresql` | PostgreSQL via `pg_dump` | [docs/sources/postgresql.md](docs/sources/postgresql.md) |

--- a/backups/main.py
+++ b/backups/main.py
@@ -58,6 +58,7 @@ default_modules = [
     'backups.sources.mysql',
     'backups.sources.postgresql',
     'backups.sources.rds',
+    'backups.sources.sftpfolder',
     'backups.sources.snapshot',
     'backups.destinations.s3',
     'backups.destinations.samba',

--- a/backups/sources/sftpfolder.py
+++ b/backups/sources/sftpfolder.py
@@ -21,21 +21,29 @@ class SFTPFolder(BackupSource):
         self.path = config['path'].rstrip('/')
         self.password = config.get('password')
         self.key_filename = config.get('key_filename')
+        self.known_hosts_file = config.get('known_hosts_file')
         self.excludes = []
         if 'excludes' in config:
             self.excludes = config['excludes']
 
-    def _walk(self, sftp, remote_path):
-        dirs = []
-        files = []
+    def _walk(self, sftp, remote_path, excludes=None):
+        if excludes is None:
+            excludes = []
+        dir_attrs = []
+        file_attrs = []
         for attr in sftp.listdir_attr(remote_path):
             if stat.S_ISDIR(attr.st_mode):
-                dirs.append(attr.filename)
+                excluded = any(
+                    fnmatch.fnmatch(attr.filename, ex) or fnmatch.fnmatch(attr.filename + '/', ex)
+                    for ex in excludes
+                )
+                if not excluded:
+                    dir_attrs.append(attr)
             else:
-                files.append(attr.filename)
-        yield remote_path, dirs, files
-        for d in dirs:
-            yield from self._walk(sftp, '%s/%s' % (remote_path, d))
+                file_attrs.append(attr)
+        yield remote_path, dir_attrs, file_attrs
+        for dattr in dir_attrs:
+            yield from self._walk(sftp, '%s/%s' % (remote_path, dattr.filename), excludes)
 
     def dump(self):
         tarfilename = '%s/%s.tar' % (self.tmpdir, self.id)
@@ -43,7 +51,10 @@ class SFTPFolder(BackupSource):
                      self.name, self.type, self.sshuser, self.sshhost, self.path)
 
         client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.load_system_host_keys()
+        if self.known_hosts_file:
+            client.load_host_keys(self.known_hosts_file)
+        client.set_missing_host_key_policy(paramiko.RejectPolicy())
         try:
             connect_kwargs = {
                 'hostname': self.sshhost,
@@ -58,26 +69,32 @@ class SFTPFolder(BackupSource):
 
             sftp = client.open_sftp()
             with tarfile.open(tarfilename, 'w') as tar:
-                for root, dirs, files in self._walk(sftp, self.path):
-                    for fname in files:
-                        remote_path = '%s/%s' % (root, fname)
+                for root, dir_attrs, file_attrs in self._walk(sftp, self.path, self.excludes):
+                    for dattr in dir_attrs:
+                        arcname = os.path.relpath('%s/%s' % (root, dattr.filename), self.path)
+                        info = tarfile.TarInfo(name=arcname)
+                        info.type = tarfile.DIRTYPE
+                        info.mtime = dattr.st_mtime
+                        info.mode = stat.S_IMODE(dattr.st_mode)
+                        tar.addfile(info)
+
+                    for fattr in file_attrs:
+                        remote_path = '%s/%s' % (root, fattr.filename)
                         arcname = os.path.relpath(remote_path, self.path)
 
-                        excluded = False
-                        for exclude in self.excludes:
-                            if fnmatch.fnmatch(arcname, exclude) or fnmatch.fnmatch(fname, exclude):
-                                excluded = True
-                                break
+                        excluded = any(
+                            fnmatch.fnmatch(arcname, ex) or fnmatch.fnmatch(fattr.filename, ex)
+                            for ex in self.excludes
+                        )
                         if excluded:
                             continue
 
                         try:
-                            attr = sftp.stat(remote_path)
                             with sftp.open(remote_path, 'rb') as f:
                                 info = tarfile.TarInfo(name=arcname)
-                                info.size = attr.st_size
-                                info.mtime = attr.st_mtime
-                                info.mode = stat.S_IMODE(attr.st_mode)
+                                info.size = fattr.st_size
+                                info.mtime = fattr.st_mtime
+                                info.mode = stat.S_IMODE(fattr.st_mode)
                                 tar.addfile(info, f)
                         except Exception as e:
                             raise BackupException(

--- a/backups/sources/sftpfolder.py
+++ b/backups/sources/sftpfolder.py
@@ -1,0 +1,92 @@
+import os, os.path
+import stat
+import fnmatch
+import logging
+import tarfile
+
+import paramiko
+
+from backups.sources import backupsource
+from backups.sources.source import BackupSource
+from backups.exceptions import BackupException
+
+
+@backupsource('sftp-folder')
+class SFTPFolder(BackupSource):
+    def __init__(self, config, type="SFTPFolder"):
+        BackupSource.__init__(self, config, type, "tar.gpg")
+        self.sshhost = config['sshhost']
+        self.sshuser = config['sshuser']
+        self.sshport = int(config.get('sshport', 22))
+        self.path = config['path'].rstrip('/')
+        self.password = config.get('password')
+        self.key_filename = config.get('key_filename')
+        self.excludes = []
+        if 'excludes' in config:
+            self.excludes = config['excludes']
+
+    def _walk(self, sftp, remote_path):
+        dirs = []
+        files = []
+        for attr in sftp.listdir_attr(remote_path):
+            if stat.S_ISDIR(attr.st_mode):
+                dirs.append(attr.filename)
+            else:
+                files.append(attr.filename)
+        yield remote_path, dirs, files
+        for d in dirs:
+            yield from self._walk(sftp, '%s/%s' % (remote_path, d))
+
+    def dump(self):
+        tarfilename = '%s/%s.tar' % (self.tmpdir, self.id)
+        logging.info("Backing up '%s' (%s) from %s@%s:%s...",
+                     self.name, self.type, self.sshuser, self.sshhost, self.path)
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+            connect_kwargs = {
+                'hostname': self.sshhost,
+                'port': self.sshport,
+                'username': self.sshuser,
+            }
+            if self.password:
+                connect_kwargs['password'] = self.password
+            if self.key_filename:
+                connect_kwargs['key_filename'] = self.key_filename
+            client.connect(**connect_kwargs)
+
+            sftp = client.open_sftp()
+            with tarfile.open(tarfilename, 'w') as tar:
+                for root, dirs, files in self._walk(sftp, self.path):
+                    for fname in files:
+                        remote_path = '%s/%s' % (root, fname)
+                        arcname = os.path.relpath(remote_path, self.path)
+
+                        excluded = False
+                        for exclude in self.excludes:
+                            if fnmatch.fnmatch(arcname, exclude) or fnmatch.fnmatch(fname, exclude):
+                                excluded = True
+                                break
+                        if excluded:
+                            continue
+
+                        try:
+                            attr = sftp.stat(remote_path)
+                            with sftp.open(remote_path, 'rb') as f:
+                                info = tarfile.TarInfo(name=arcname)
+                                info.size = attr.st_size
+                                info.mtime = attr.st_mtime
+                                info.mode = stat.S_IMODE(attr.st_mode)
+                                tar.addfile(info, f)
+                        except Exception as e:
+                            raise BackupException(
+                                "Error downloading '%s' via SFTP: %s" % (remote_path, e))
+        except BackupException:
+            raise
+        except Exception as e:
+            raise BackupException("SFTP connection error: %s" % e)
+        finally:
+            client.close()
+
+        return [tarfilename, ]

--- a/docs/sources/sftpfolder.md
+++ b/docs/sources/sftpfolder.md
@@ -1,0 +1,42 @@
+# Source: Folder via SFTP
+
+Backs up a remote directory over SFTP by recursively walking and packing files into a tar archive.
+
+**Module**: `backups.sources.sftpfolder`
+
+## Example
+
+```json
+{
+  "id": "remote-data",
+  "type": "sftp-folder",
+  "name": "Remote server data",
+  "sshhost": "server.example.com",
+  "sshuser": "backups",
+  "path": "/var/www",
+  "password": "your-sftp-password",
+  "excludes": ["*.log", "cache/"],
+  "passphrase": "your-encryption-passphrase"
+}
+```
+
+## Parameters
+
+| Key | Required | Purpose |
+|-----|----------|---------|
+| `id` | Yes | Unique identifier for this source. |
+| `name` | No | Description for reporting (defaults to `id`). |
+| `sshhost` | Yes | Remote hostname to connect to. |
+| `sshuser` | Yes | SFTP username. |
+| `path` | Yes | Remote directory to back up. |
+| `sshport` | No | SSH port (defaults to `22`). |
+| `password` | No | Password for password-based authentication. |
+| `key_filename` | No | Path to a private key file for key-based authentication. |
+| `excludes` | No | Array of glob patterns (fnmatch) to exclude from the backup. Patterns are matched against both the filename and the archive path. |
+| `passphrase` | No | Passphrase for symmetric GPG encryption. |
+| `recipients` | No | Array of GPG key recipients for asymmetric encryption. |
+| `compress_only` | No | Set to `1` to skip encryption and only compress. |
+
+## Notes
+
+The backup host must have network access to the remote host on the configured port. Authentication can use either a password or an SSH private key.

--- a/docs/sources/sftpfolder.md
+++ b/docs/sources/sftpfolder.md
@@ -32,7 +32,8 @@ Backs up a remote directory over SFTP by recursively walking and packing files i
 | `sshport` | No | SSH port (defaults to `22`). |
 | `password` | No | Password for password-based authentication. |
 | `key_filename` | No | Path to a private key file for key-based authentication. |
-| `excludes` | No | Array of glob patterns (fnmatch) to exclude from the backup. Patterns are matched against both the filename and the archive path. |
+| `known_hosts_file` | No | Path to an additional known_hosts file to load alongside the system known_hosts. |
+| `excludes` | No | Array of glob patterns (fnmatch) to exclude from the backup. File patterns (e.g. `*.log`) are matched against the filename and archive path. Directory patterns (e.g. `cache/`) prune the entire subtree from the walk. |
 | `passphrase` | No | Passphrase for symmetric GPG encryption. |
 | `recipients` | No | Array of GPG key recipients for asymmetric encryption. |
 | `compress_only` | No | Set to `1` to skip encryption and only compress. |
@@ -40,3 +41,5 @@ Backs up a remote directory over SFTP by recursively walking and packing files i
 ## Notes
 
 The backup host must have network access to the remote host on the configured port. Authentication can use either a password or an SSH private key.
+
+The remote host's key must be present in the system known_hosts file (`~/.ssh/known_hosts`) before running a backup. Use `ssh-keyscan` to add it first, or specify an alternative file via `known_hosts_file`. Connections to hosts with unknown keys are rejected.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name = 'backups',
     install_requires = [
         'requests',
         'python-dateutil',
+        'paramiko',
     ],
     extras_require = {
         'tracing': [

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -11,6 +11,7 @@ from backups.sources.postgresql import PostgreSQL
 from backups.sources.folderssh import FolderSSH
 from backups.sources.lvmssh import LVMLogicalVolume, dev_mapper_name
 from backups.sources.snapshot import Snapshot
+from backups.sources.sftpfolder import SFTPFolder
 from backups.exceptions import BackupException
 
 # Azure SDK is optional; inject stubs before importing the module
@@ -613,3 +614,231 @@ class TestAzureManagedDisk:
         assert disk.disk_name == 'datadisk'
         assert disk.retain_snapshots == 3
         assert disk.type == 'AzureManagedDisk'
+
+
+class TestSFTPFolder:
+    def test_init(self):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+            'password': 'secret',
+            'excludes': ['*.log'],
+        }
+        source = SFTPFolder(config)
+        assert source.sshhost == 'example.com'
+        assert source.sshuser == 'backupuser'
+        assert source.sshport == 22
+        assert source.path == '/remote/path'
+        assert source.password == 'secret'
+        assert source.key_filename is None
+        assert source.excludes == ['*.log']
+        assert source.type == 'SFTPFolder'
+
+    def test_init_defaults(self):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+        }
+        source = SFTPFolder(config)
+        assert source.sshport == 22
+        assert source.excludes == []
+        assert source.password is None
+        assert source.key_filename is None
+
+    def test_init_custom_port(self):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+            'sshport': 2222,
+            'key_filename': '/path/to/key',
+        }
+        source = SFTPFolder(config)
+        assert source.sshport == 2222
+        assert source.key_filename == '/path/to/key'
+
+    def test_walk(self):
+        import stat as stat_module
+        source = SFTPFolder({
+            'id': 'test',
+            'sshhost': 'h',
+            'sshuser': 'u',
+            'path': '/remote',
+        })
+        mock_sftp = Mock()
+
+        def listdir_attr_side_effect(path):
+            if path == '/remote':
+                dir_attr = Mock()
+                dir_attr.filename = 'subdir'
+                dir_attr.st_mode = stat_module.S_IFDIR | 0o755
+                file_attr = Mock()
+                file_attr.filename = 'file.txt'
+                file_attr.st_mode = stat_module.S_IFREG | 0o644
+                return [dir_attr, file_attr]
+            elif path == '/remote/subdir':
+                nested_attr = Mock()
+                nested_attr.filename = 'nested.txt'
+                nested_attr.st_mode = stat_module.S_IFREG | 0o644
+                return [nested_attr]
+            return []
+
+        mock_sftp.listdir_attr.side_effect = listdir_attr_side_effect
+
+        result = list(source._walk(mock_sftp, '/remote'))
+
+        assert len(result) == 2
+        assert result[0] == ('/remote', ['subdir'], ['file.txt'])
+        assert result[1] == ('/remote/subdir', [], ['nested.txt'])
+
+    @patch('backups.sources.sftpfolder.tarfile.open')
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_success(self, mock_ssh_client, mock_tar_open):
+        import stat as stat_module
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+        }
+        source = SFTPFolder(config)
+        source.id = 'testid'
+        source.name = 'testname'
+        source.tmpdir = '/tmp'
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        file_attr = Mock()
+        file_attr.filename = 'file.txt'
+        file_attr.st_mode = stat_module.S_IFREG | 0o644
+        mock_sftp.listdir_attr.return_value = [file_attr]
+
+        stat_result = Mock()
+        stat_result.st_size = 100
+        stat_result.st_mtime = 1234567890
+        stat_result.st_mode = stat_module.S_IFREG | 0o644
+        mock_sftp.stat.return_value = stat_result
+
+        mock_file = MagicMock()
+        mock_sftp.open.return_value = MagicMock()
+        mock_sftp.open.return_value.__enter__.return_value = mock_file
+
+        mock_tar = MagicMock()
+        mock_tar_open.return_value = MagicMock()
+        mock_tar_open.return_value.__enter__.return_value = mock_tar
+
+        result = source.dump()
+
+        assert result == ['/tmp/testid.tar']
+        mock_client.connect.assert_called_once_with(
+            hostname='example.com', port=22, username='backupuser')
+        mock_client.open_sftp.assert_called_once()
+        mock_sftp.listdir_attr.assert_called_once_with('/remote/path')
+        mock_sftp.stat.assert_called_once_with('/remote/path/file.txt')
+        mock_tar.addfile.assert_called_once()
+        mock_client.close.assert_called_once()
+
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_connection_error(self, mock_ssh_client):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+        }
+        source = SFTPFolder(config)
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_client.connect.side_effect = Exception("Connection refused")
+
+        with pytest.raises(BackupException, match="SFTP connection error"):
+            source.dump()
+
+        mock_client.close.assert_called_once()
+
+    @patch('backups.sources.sftpfolder.tarfile.open')
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_with_excludes(self, mock_ssh_client, mock_tar_open):
+        import stat as stat_module
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+            'excludes': ['*.log'],
+        }
+        source = SFTPFolder(config)
+        source.tmpdir = '/tmp'
+        source.id = 'testid'
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        log_attr = Mock()
+        log_attr.filename = 'access.log'
+        log_attr.st_mode = stat_module.S_IFREG | 0o644
+        txt_attr = Mock()
+        txt_attr.filename = 'readme.txt'
+        txt_attr.st_mode = stat_module.S_IFREG | 0o644
+        mock_sftp.listdir_attr.return_value = [log_attr, txt_attr]
+
+        stat_result = Mock()
+        stat_result.st_size = 100
+        stat_result.st_mtime = 1234567890
+        stat_result.st_mode = stat_module.S_IFREG | 0o644
+        mock_sftp.stat.return_value = stat_result
+
+        mock_file = MagicMock()
+        mock_sftp.open.return_value = MagicMock()
+        mock_sftp.open.return_value.__enter__.return_value = mock_file
+
+        mock_tar = MagicMock()
+        mock_tar_open.return_value = MagicMock()
+        mock_tar_open.return_value.__enter__.return_value = mock_tar
+
+        result = source.dump()
+
+        assert result == ['/tmp/testid.tar']
+        assert mock_tar.addfile.call_count == 1
+        mock_client.close.assert_called_once()
+
+    @patch('backups.sources.sftpfolder.tarfile.open')
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_download_error(self, mock_ssh_client, mock_tar_open):
+        import stat as stat_module
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+        }
+        source = SFTPFolder(config)
+        source.tmpdir = '/tmp'
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        file_attr = Mock()
+        file_attr.filename = 'file.txt'
+        file_attr.st_mode = stat_module.S_IFREG | 0o644
+        mock_sftp.listdir_attr.return_value = [file_attr]
+
+        mock_sftp.stat.side_effect = Exception("Permission denied")
+
+        with pytest.raises(BackupException, match="Error downloading"):
+            source.dump()
+
+        mock_client.close.assert_called_once()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -11,6 +11,7 @@ from backups.sources.postgresql import PostgreSQL
 from backups.sources.folderssh import FolderSSH
 from backups.sources.lvmssh import LVMLogicalVolume, dev_mapper_name
 from backups.sources.snapshot import Snapshot
+import paramiko
 from backups.sources.sftpfolder import SFTPFolder
 from backups.exceptions import BackupException
 
@@ -648,6 +649,7 @@ class TestSFTPFolder:
         assert source.excludes == []
         assert source.password is None
         assert source.key_filename is None
+        assert source.known_hosts_file is None
 
     def test_init_custom_port(self):
         config = {
@@ -693,8 +695,46 @@ class TestSFTPFolder:
         result = list(source._walk(mock_sftp, '/remote'))
 
         assert len(result) == 2
-        assert result[0] == ('/remote', ['subdir'], ['file.txt'])
-        assert result[1] == ('/remote/subdir', [], ['nested.txt'])
+        root0, dir_attrs0, file_attrs0 = result[0]
+        assert root0 == '/remote'
+        assert [a.filename for a in dir_attrs0] == ['subdir']
+        assert [a.filename for a in file_attrs0] == ['file.txt']
+        root1, dir_attrs1, file_attrs1 = result[1]
+        assert root1 == '/remote/subdir'
+        assert dir_attrs1 == []
+        assert [a.filename for a in file_attrs1] == ['nested.txt']
+
+    def test_walk_excludes_directory(self):
+        import stat as stat_module
+        source = SFTPFolder({
+            'id': 'test',
+            'sshhost': 'h',
+            'sshuser': 'u',
+            'path': '/remote',
+        })
+        mock_sftp = Mock()
+
+        def listdir_attr_side_effect(path):
+            if path == '/remote':
+                cache_attr = Mock()
+                cache_attr.filename = 'cache'
+                cache_attr.st_mode = stat_module.S_IFDIR | 0o755
+                file_attr = Mock()
+                file_attr.filename = 'file.txt'
+                file_attr.st_mode = stat_module.S_IFREG | 0o644
+                return [cache_attr, file_attr]
+            return []
+
+        mock_sftp.listdir_attr.side_effect = listdir_attr_side_effect
+
+        result = list(source._walk(mock_sftp, '/remote', excludes=['cache/']))
+
+        assert len(result) == 1
+        root0, dir_attrs0, file_attrs0 = result[0]
+        assert root0 == '/remote'
+        assert dir_attrs0 == []
+        assert [a.filename for a in file_attrs0] == ['file.txt']
+        mock_sftp.listdir_attr.assert_called_once_with('/remote')
 
     @patch('backups.sources.sftpfolder.tarfile.open')
     @patch('backups.sources.sftpfolder.paramiko.SSHClient')
@@ -719,13 +759,9 @@ class TestSFTPFolder:
         file_attr = Mock()
         file_attr.filename = 'file.txt'
         file_attr.st_mode = stat_module.S_IFREG | 0o644
+        file_attr.st_size = 100
+        file_attr.st_mtime = 1234567890
         mock_sftp.listdir_attr.return_value = [file_attr]
-
-        stat_result = Mock()
-        stat_result.st_size = 100
-        stat_result.st_mtime = 1234567890
-        stat_result.st_mode = stat_module.S_IFREG | 0o644
-        mock_sftp.stat.return_value = stat_result
 
         mock_file = MagicMock()
         mock_sftp.open.return_value = MagicMock()
@@ -738,12 +774,68 @@ class TestSFTPFolder:
         result = source.dump()
 
         assert result == ['/tmp/testid.tar']
+        mock_client.load_system_host_keys.assert_called_once()
+        mock_client.load_host_keys.assert_not_called()
+        policy_arg = mock_client.set_missing_host_key_policy.call_args[0][0]
+        assert isinstance(policy_arg, paramiko.RejectPolicy)
         mock_client.connect.assert_called_once_with(
             hostname='example.com', port=22, username='backupuser')
         mock_client.open_sftp.assert_called_once()
         mock_sftp.listdir_attr.assert_called_once_with('/remote/path')
-        mock_sftp.stat.assert_called_once_with('/remote/path/file.txt')
+        mock_sftp.stat.assert_not_called()
         mock_tar.addfile.assert_called_once()
+        mock_client.close.assert_called_once()
+
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_unknown_host(self, mock_ssh_client):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+        }
+        source = SFTPFolder(config)
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_client.connect.side_effect = paramiko.SSHException(
+            "Server 'example.com' not found in known_hosts")
+
+        with pytest.raises(BackupException, match="SFTP connection error"):
+            source.dump()
+
+        mock_client.load_system_host_keys.assert_called_once()
+        policy_arg = mock_client.set_missing_host_key_policy.call_args[0][0]
+        assert isinstance(policy_arg, paramiko.RejectPolicy)
+        mock_client.close.assert_called_once()
+
+    @patch('backups.sources.sftpfolder.tarfile.open')
+    @patch('backups.sources.sftpfolder.paramiko.SSHClient')
+    def test_dump_with_known_hosts_file(self, mock_ssh_client, mock_tar_open):
+        config = {
+            'id': 'test-sftp',
+            'sshhost': 'example.com',
+            'sshuser': 'backupuser',
+            'path': '/remote/path',
+            'known_hosts_file': '/etc/backup/known_hosts',
+        }
+        source = SFTPFolder(config)
+        source.tmpdir = '/tmp'
+        source.id = 'testid'
+
+        mock_client = Mock()
+        mock_ssh_client.return_value = mock_client
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+        mock_sftp.listdir_attr.return_value = []
+
+        mock_tar_open.return_value = MagicMock()
+        mock_tar_open.return_value.__enter__.return_value = MagicMock()
+
+        source.dump()
+
+        mock_client.load_system_host_keys.assert_called_once()
+        mock_client.load_host_keys.assert_called_once_with('/etc/backup/known_hosts')
         mock_client.close.assert_called_once()
 
     @patch('backups.sources.sftpfolder.paramiko.SSHClient')
@@ -791,13 +883,9 @@ class TestSFTPFolder:
         txt_attr = Mock()
         txt_attr.filename = 'readme.txt'
         txt_attr.st_mode = stat_module.S_IFREG | 0o644
+        txt_attr.st_size = 50
+        txt_attr.st_mtime = 1234567890
         mock_sftp.listdir_attr.return_value = [log_attr, txt_attr]
-
-        stat_result = Mock()
-        stat_result.st_size = 100
-        stat_result.st_mtime = 1234567890
-        stat_result.st_mode = stat_module.S_IFREG | 0o644
-        mock_sftp.stat.return_value = stat_result
 
         mock_file = MagicMock()
         mock_sftp.open.return_value = MagicMock()
@@ -836,7 +924,7 @@ class TestSFTPFolder:
         file_attr.st_mode = stat_module.S_IFREG | 0o644
         mock_sftp.listdir_attr.return_value = [file_attr]
 
-        mock_sftp.stat.side_effect = Exception("Permission denied")
+        mock_sftp.open.side_effect = Exception("Permission denied")
 
         with pytest.raises(BackupException, match="Error downloading"):
             source.dump()


### PR DESCRIPTION
## Summary

Adds a new `sftp-folder` source type that backs up a remote directory by recursively fetching files over SFTP and packing them into a tar archive.

- **`backups/sources/sftpfolder.py`** — New source registered as `sftp-folder`. Uses paramiko to recursively walk an SFTP remote path and write files into a tar archive. Supports password and key-based auth, custom port, and fnmatch exclude patterns.
- **`setup.py`** — Added `paramiko` dependency.
- **`backups/main.py`** — Registered module in default_modules.
- **`docs/sources/sftpfolder.md`** — Full documentation with example config and parameter table.
- **`README.md`** — Added row to sources table.
- **`tests/test_sources.py`** — 8 tests covering init, walk, dump, excludes, connection error, and download error.