### PR TITLE
Add top-level encryption config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Or per-source:
 
 Use `passphrase` for symmetric GPG encryption, or `recipients` (array) for asymmetric/GPG public key encryption.
 
+> **Override semantics**: if a source defines either `passphrase` or `recipients`, the top-level `encryption` block is ignored entirely for that source.
+
+> **Note**: older configs containing `"type": "symmetric"` or `"type": "asymmetric"` fields in the encryption block should be updated — those fields were never implemented and are ignored.
+
 ## Tracing Configuration
 
 OpenTelemetry OTLP tracing is supported for observability. Tracing is disabled by default (zero performance impact).

--- a/README.md
+++ b/README.md
@@ -26,27 +26,37 @@ Configuration is a single JSON file:
 
 ### Encryption (optional)
 
-Add to the top level to encrypt backups before upload:
+Encryption can be specified at the top level (applies to all sources) or per-source. Per-source settings override top-level.
 
+Top-level (applies to all sources):
 ```json
 {
   "encryption": {
-    "type": "symmetric",
     "passphrase": "YOUR_PASSPHRASE"
-  }
+  },
+  "sources": [...]
 }
 ```
 
-Or asymmetric (GPG public key):
-
+Or per-source:
 ```json
 {
-  "encryption": {
-    "type": "asymmetric",
-    "recipient": "ops@example.com"
-  }
+  "sources": [
+    {
+      "name": "mysql-db",
+      "type": "mysql",
+      "passphrase": "YOUR_PASSPHRASE"
+    },
+    {
+      "name": "pg-db",
+      "type": "postgresql",
+      "recipients": ["ops@example.com"]
+    }
+  ]
 }
 ```
+
+Use `passphrase` for symmetric GPG encryption, or `recipients` (array) for asymmetric/GPG public key encryption.
 
 ## Tracing Configuration
 

--- a/backups/main.py
+++ b/backups/main.py
@@ -259,11 +259,18 @@ def main():
                     notifications.append(notification)
 
         # Loop through sections, process those we have sources for
+        global_encryption = config.get('encryption', {})
         sources = []
         for source_id, source_class in backups.sources.handlers.items():
             logging.debug("Source(%s) - %s" % (source_id, source_class))
             for source_config in config['sources']:
                 if source_config['type'] == source_id:
+                    source_config = dict(source_config)
+                    if 'passphrase' not in source_config and 'recipients' not in source_config:
+                        if 'passphrase' in global_encryption:
+                            source_config['passphrase'] = global_encryption['passphrase']
+                        if 'recipients' in global_encryption:
+                            source_config['recipients'] = global_encryption['recipients']
                     source = source_class(source_config)
                     source.tracer = otel_tracer
                     sources.append(source)

--- a/backups/main.py
+++ b/backups/main.py
@@ -51,6 +51,16 @@ class _NoOpTracer:
         yield _NoOpSpan()
 
 
+def _apply_default_encryption(source_config, default_encryption):
+    source_config = dict(source_config)
+    if 'passphrase' not in source_config and 'recipients' not in source_config:
+        if 'passphrase' in default_encryption:
+            source_config['passphrase'] = default_encryption['passphrase']
+        if 'recipients' in default_encryption:
+            source_config['recipients'] = default_encryption['recipients']
+    return source_config
+
+
 # Default set of modules to import
 default_modules = [
     'backups.sources.azure_managed_disk',
@@ -259,18 +269,15 @@ def main():
                     notifications.append(notification)
 
         # Loop through sections, process those we have sources for
-        global_encryption = config.get('encryption', {})
+        default_encryption = config.get('encryption', {})
+        if 'passphrase' in default_encryption and 'recipients' in default_encryption:
+            logging.warning("Top-level encryption block has both 'passphrase' and 'recipients'; 'recipients' takes priority")
         sources = []
         for source_id, source_class in backups.sources.handlers.items():
             logging.debug("Source(%s) - %s" % (source_id, source_class))
             for source_config in config['sources']:
                 if source_config['type'] == source_id:
-                    source_config = dict(source_config)
-                    if 'passphrase' not in source_config and 'recipients' not in source_config:
-                        if 'passphrase' in global_encryption:
-                            source_config['passphrase'] = global_encryption['passphrase']
-                        if 'recipients' in global_encryption:
-                            source_config['recipients'] = global_encryption['recipients']
+                    source_config = _apply_default_encryption(source_config, default_encryption)
                     source = source_class(source_config)
                     source.tracer = otel_tracer
                     sources.append(source)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -230,3 +230,41 @@ class TestTracing:
         instance.destinations = []
         instance.notifications = []
         instance.run()
+
+
+class TestApplyDefaultEncryption:
+    def test_global_passphrase_applied_to_source(self):
+        src = {'type': 'mysql', 'name': 'db'}
+        result = backups.main._apply_default_encryption(src, {'passphrase': 'secret'})
+        assert result['passphrase'] == 'secret'
+
+    def test_global_recipients_applied_to_source(self):
+        src = {'type': 'mysql', 'name': 'db'}
+        result = backups.main._apply_default_encryption(src, {'recipients': ['ops@example.com']})
+        assert result['recipients'] == ['ops@example.com']
+
+    def test_per_source_passphrase_overrides_global(self):
+        src = {'type': 'mysql', 'name': 'db', 'passphrase': 'mine'}
+        result = backups.main._apply_default_encryption(src, {'passphrase': 'global'})
+        assert result['passphrase'] == 'mine'
+
+    def test_per_source_recipients_overrides_global(self):
+        src = {'type': 'mysql', 'name': 'db', 'recipients': ['local@example.com']}
+        result = backups.main._apply_default_encryption(src, {'recipients': ['global@example.com']})
+        assert result['recipients'] == ['local@example.com']
+
+    def test_per_source_passphrase_blocks_global_recipients(self):
+        src = {'type': 'mysql', 'name': 'db', 'passphrase': 'mine'}
+        result = backups.main._apply_default_encryption(src, {'recipients': ['global@example.com']})
+        assert 'recipients' not in result
+
+    def test_no_global_encryption(self):
+        src = {'type': 'mysql', 'name': 'db'}
+        result = backups.main._apply_default_encryption(src, {})
+        assert 'passphrase' not in result
+        assert 'recipients' not in result
+
+    def test_original_config_not_mutated(self):
+        src = {'type': 'mysql', 'name': 'db'}
+        backups.main._apply_default_encryption(src, {'passphrase': 'secret'})
+        assert 'passphrase' not in src


### PR DESCRIPTION
Fixes the README which incorrectly documented encryption as top-level, and adds actual support for top-level encryption that applies to all sources (with per-source override).

### Changes:
- README now correctly documents that encryption is per-source
- Added support for top-level `encryption` block in config
- Per-source `passphrase`/`recipients` overrides top-level settings

### Example usage:

Top-level (applies to all sources):
```json
{
  "encryption": {
    "passphrase": "YOUR_PASSPHRASE"
  },
  "sources": [...]
}
```

Or per-source (overrides top-level):
```json
{
  "sources": [
    {
      "name": "mysql-db",
      "type": "mysql",
      "passphrase": "source-specific-passphrase"
    }
  ]
}
```